### PR TITLE
fix req.headers by req.cookies

### DIFF
--- a/controllers/customersController.js
+++ b/controllers/customersController.js
@@ -3,7 +3,7 @@ const expressAsyncHandler = require('express-async-handler');
 const jwt = require('jsonwebtoken');
 
 const getAllCustomers = expressAsyncHandler(async (req, res) => {
-  const token = req.headers.authorization;
+  const token = req.cookies.token;
   if (!token || !token.startsWith('Bearer ')) {
     res.status(401).json({
       code: 401,
@@ -24,7 +24,7 @@ const getAllCustomers = expressAsyncHandler(async (req, res) => {
 });
 
 const getCustomer = expressAsyncHandler(async (req, res) => {
-  const token = req.headers.authorization;
+  const token = req.cookies.token;
   if (!token || !token.startsWith('Bearer ')) {
     res.status(401).json({
       code: 401,
@@ -45,7 +45,7 @@ const getCustomer = expressAsyncHandler(async (req, res) => {
 });
 
 const createCustomer = expressAsyncHandler(async (req, res) => {
-  const token = req.headers.authorization;
+  const token = req.cookies.token;
   if (!token || !token.startsWith('Bearer ')) {
     res.status(401).json({
       code: 401,
@@ -75,7 +75,7 @@ const createCustomer = expressAsyncHandler(async (req, res) => {
 });
 
 const updateCustomer = expressAsyncHandler(async (req, res) => {
-  const token = req.headers.authorization;
+  const token = req.cookies.token;
   if (!token || !token.startsWith('Bearer ')) {
     return res.status(401).json({
       code: 401,
@@ -135,7 +135,7 @@ const updateCustomer = expressAsyncHandler(async (req, res) => {
 });
 
 const deleteCustomer = expressAsyncHandler(async (req, res) => {
-  const token = req.headers.authorization;
+  const token = req.cookies.token;
   if (!token || !token.startsWith('Bearer ')) {
     return res.status(401).json({
       code: 401,

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -135,7 +135,7 @@ const updateUser = expressAsyncHandler(async (req, res) => {
 });
 
 const updatePassword = expressAsyncHandler(async (req, res) => {
-  const authHeader = req.headers.authorization;
+  const authHeader = req.cookies.token;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     res.status(401).json({
       code: '401',


### PR DESCRIPTION
Corregí el cómo se obtiene el token de la request. Nosotros estamos usando cookies, por lo que podemos obtener el token mediante la cookie y no por los headers directamente. Considerar para los otros endpoints o donde sea que se tenga que validar.